### PR TITLE
[DEV-67] Used hasch edn-hash function instead of Clojure's

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,12 @@
                               :username :env
                               :password :env}]]
 
-  :dependencies [[org.clojure/tools.logging "0.3.1"]
-                 [clj-logging-config "1.9.12"]
-                 [prismatic/plumbing "0.5.3"]
+  :dependencies [[clj-logging-config "1.9.12"]
+                 [environ "1.0.3"]
+                 [io.replikativ/hasch "0.3.4"]
+                 [org.clojure/tools.logging "0.3.1"]
                  [pjstadig/humane-test-output "0.8.0"]
-                 [environ "1.0.3"]]
+                 [prismatic/plumbing "0.5.3"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :test {:dependencies [[org.clojure/tools.nrepl "0.2.12"]

--- a/src/views/core.clj
+++ b/src/views/core.clj
@@ -2,10 +2,11 @@
   (:import
     [java.util.concurrent ArrayBlockingQueue TimeUnit])
   (:require
-    [views.protocols :refer [IView id data relevant?]]
-    [plumbing.core :refer [swap-pair!]]
     [clojure.tools.logging :refer [info debug error]]
-    [environ.core :refer [env]]))
+    [environ.core :refer [env]]
+    [plumbing.core :refer [swap-pair!]]
+    [views.hash :refer [hash]]
+    [views.protocols :refer [IView id data relevant?]]))
 
 ;; The view-system data structure has this shape:
 ;;

--- a/src/views/core.clj
+++ b/src/views/core.clj
@@ -5,7 +5,7 @@
     [clojure.tools.logging :refer [info debug error]]
     [environ.core :refer [env]]
     [plumbing.core :refer [swap-pair!]]
-    [views.hash :refer [hash]]
+    [views.hash :refer [md5-hash]]
     [views.protocols :refer [IView id data relevant?]]))
 
 ;; The view-system data structure has this shape:
@@ -65,7 +65,7 @@
       (future
         (try
           (let [vdata     (data view namespace parameters)
-                data-hash (hash vdata)]
+                data-hash (md5-hash vdata)]
             ;; Check to make sure that we are still subscribed. It's possible that
             ;; an unsubscription event came in while computing the view.
             (when (contains? (get-in @view-system [:subscribed subscriber-key]) view-sig)
@@ -156,7 +156,7 @@
       (try
         (let [view  (get-in @view-system [:views view-id])
               vdata (data view namespace parameters)
-              hdata (hash vdata)]
+              hdata (md5-hash vdata)]
           (when-not (= hdata (get-in @view-system [:hashes view-sig]))
             (doseq [s (get-in @view-system [:subscribers view-sig])]
               ((:send-fn @view-system) s [[view-id parameters] vdata]))

--- a/src/views/hash.clj
+++ b/src/views/hash.clj
@@ -1,15 +1,19 @@
 (ns views.hash
   (:require
-    [hasch.benc :refer [magics PHashCoercion -coerce digest coerce-seq xor-hashes encode-safe]]
+    [hasch.benc :refer [-coerce magics PHashCoercion]]
     [hasch.core :refer [edn-hash]]
     [hasch.platform :refer [encode md5-message-digest]]))
 
 (extend-protocol PHashCoercion
   java.math.BigDecimal
   (-coerce [this md-create-fn write-handlers]
+    (encode (:number magics) (.getBytes (.toString this) "UTF-8")))
+
+  clojure.lang.BigInt
+  (-coerce [this md-create-fn write-handlers]
     (encode (:number magics) (.getBytes (.toString this) "UTF-8"))))
 
-(defn hash
+(defn md5-hash
   "This hashing function is a drop-in replacement of Clojure's hash function. Unfortunately, Clojure's
    hash function has the same result for 0 and nil values. Therefore, passing from nil or 0 to the
    other won't trigger a view refresh."

--- a/src/views/hash.clj
+++ b/src/views/hash.clj
@@ -1,0 +1,17 @@
+(ns views.hash
+  (:require
+    [hasch.benc :refer [magics PHashCoercion -coerce digest coerce-seq xor-hashes encode-safe]]
+    [hasch.core :refer [edn-hash]]
+    [hasch.platform :refer [encode md5-message-digest]]))
+
+(extend-protocol PHashCoercion
+  java.math.BigDecimal
+  (-coerce [this md-create-fn write-handlers]
+    (encode (:number magics) (.getBytes (.toString this) "UTF-8"))))
+
+(defn hash
+  "This hashing function is a drop-in replacement of Clojure's hash function. Unfortunately, Clojure's
+   hash function has the same result for 0 and nil values. Therefore, passing from nil or 0 to the
+   other won't trigger a view refresh."
+  [value]
+  (edn-hash value md5-message-digest {}))

--- a/test/views/hash_test.clj
+++ b/test/views/hash_test.clj
@@ -1,0 +1,39 @@
+(ns views.hash-test
+  (:require
+    [clojure.test :refer [are is deftest testing]]
+    [views.hash :refer [md5-hash]]))
+
+(deftest hash-algorithm
+  (testing "Basic tests to make sure it produces a consistent hash"
+    (are [x y]
+      (= (md5-hash x) (md5-hash y))
+      1 1
+      0.5 0.5
+      1N 1N
+      1M 1M
+      1N 1M
+      true true
+      "test string" "test string"
+      [0 1 2 3] [0 1 2 3]
+      '(0 1 2 3) '(0 1 2 3)
+      #{0 1 2 3} #{3 2 1 0})
+
+    (are [x y]
+      (not= (md5-hash x) (md5-hash y))
+      1 0
+      1 1.0
+      true false
+      "test string" "string"
+      [0 1 2 3] [2 3]
+      '(0 1 2 3) '(2 3)
+      #{0 1 2 3} #{2 3}
+      1 true
+      false [1]))
+
+  (testing "Zero and nils are not equal"
+    (are [x y]
+      (not= (md5-hash x) (md5-hash y))
+      0 nil
+      {:a 0} {:a nil}
+      #{0} #{nil}
+      [0] [nil])))


### PR DESCRIPTION
Unfortunately, Clojure's hash function will return the same value for `0` and `nil`. Therefore, `[{:a nil, :b nil, :c nil, :d 1}]` is considered `=` to `[{:a 0, :b 0, :c 0, :d 1}]`. In this case, the view system won't send view refreshes if there's a transition between these values.

Most of Clojure's library try to mimic Java's hashCode where 0 and nil share the same hash code.
> public static int hashCode(Object o)
> Returns the hash code of a non-null argument and 0 for a null argument.

By going over a lot libraries, hasch (https://github.com/replikativ/hasch) seems to be our best bet. By default, it uses `sha-512` to generate 64 bytes digests, but I decided to use a smaller digest (MD5 -> 16 bytes) at the cost of potentially more collisions. Of course, the new hash function takes more time and more memory, but...