### PR TITLE
[DEV-812] divide by zero in views statistics

### DIFF
--- a/src/views/core.clj
+++ b/src/views/core.clj
@@ -430,7 +430,7 @@
               ; to make use of any options themselves
               :options       options})
      (start-update-watcher! view-system (:refresh-interval options) (:worker-threads options))
-     (when-let [stats-log-interval (:stats-log-interval options)]
+     (when-let [stats-log-interval (some-> (:stats-log-interval options) pos?)]
        (statistics/start-logger! view-system stats-log-interval))
      view-system))
   ([options]

--- a/src/views/core.clj
+++ b/src/views/core.clj
@@ -415,7 +415,8 @@
    and the defaults that will be used for any options not provided in
    the call to init!."
   ([view-system options]
-   (let [options (merge default-options options)]
+   (let [options (merge default-options options)
+         stats-log-interval (:stats-log-interval options)]
      (debug "initializing views system using options:" options)
      (reset! view-system
              {:refresh-queue (ArrayBlockingQueue. (:refresh-queue-size options))
@@ -430,7 +431,7 @@
               ; to make use of any options themselves
               :options       options})
      (start-update-watcher! view-system (:refresh-interval options) (:worker-threads options))
-     (when-let [stats-log-interval (some-> (:stats-log-interval options) pos?)]
+     (when (some-> stats-log-interval pos?)
        (statistics/start-logger! view-system stats-log-interval))
      view-system))
   ([options]


### PR DESCRIPTION
The old version had the caller check for zero before calling `log-statistics!`, but the new streamlined way handles everything internally. So we handle the zero case internally here as well.