### PR TITLE
Add missing deref to fix 'subscribed views' stats

### DIFF
--- a/src/views/statistics.clj
+++ b/src/views/statistics.clj
@@ -5,7 +5,7 @@
 (defn active-view-count
   "Returns a count of views with at least one subscriber."
   [view-system]
-  (count (remove #(empty? (val %)) (:subscribers view-system))))
+  (count (remove #(empty? (val %)) (:subscribers @view-system))))
 
 (defn collecting?
   "Whether view statem statistics collection and logging is enabled or not."


### PR DESCRIPTION
The message now shows the count of subscribed views correctly:
```
2018-10-16 01:05:31,968 [Thread-28] INFO  [views.statistics] - subscribed views: 57 refreshes/sec: 0.0 dropped/sec: 0.0 deduped/sec: 0.0
```